### PR TITLE
small alterations to docker-zenbu 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ MAINTAINER Roberto Vera Alvarez <r78v10a07@gmail.com>
 
 ENV CMAKE_URL=https://cmake.org/files/v3.13/
 ENV CMAKE_INSTALLER=cmake-3.13.0-rc3-Linux-x86_64.sh
-ZENBU_URL=https://github.com/jessica-severin/ZENBU_2.11.git
+ENV ZENBU_URL=https://github.com/jessica-severin/ZENBU_2.11
 ENV ZENBU_FOLDER=ZENBU_2.11
 ENV BAMTOOLS_URL=https://github.com/pezmaster31/bamtools
 ENV FOLDER=ZENBU

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM debian:7
 LABEL base.image="debian:7"
 LABEL version="3"
 LABEL software="ZENBU"
-LABEL software.version="2.11.2"
+LABEL software.version="2.11"
 LABEL description=""
 LABEL website="http://fantom.gsc.riken.jp/zenbu/"
 LABEL documentation="https://zenbu-wiki.gsc.riken.jp/zenbu/wiki/index.php/Main_Page"
@@ -16,8 +16,8 @@ MAINTAINER Roberto Vera Alvarez <r78v10a07@gmail.com>
 
 ENV CMAKE_URL=https://cmake.org/files/v3.13/
 ENV CMAKE_INSTALLER=cmake-3.13.0-rc3-Linux-x86_64.sh
-ENV ZENBU_URL=https://pilotfiber.dl.sourceforge.net/project/zenbu/
-ENV ZENBU_FOLDER=ZENBU_2.11.1
+ZENBU_URL=https://github.com/jessica-severin/ZENBU_2.11.git
+ENV ZENBU_FOLDER=ZENBU_2.11
 ENV BAMTOOLS_URL=https://github.com/pezmaster31/bamtools
 ENV FOLDER=ZENBU
 ENV BAMTOOLS_FOLDER=bamtools
@@ -74,8 +74,7 @@ COPY zenbu_build_debian.sh /sbin/zenbu_build_debian.sh
 RUN chmod 755 /sbin/zenbu_build_debian.sh
 
 RUN cd $DST && \
-    wget $ZENBU_URL/${ZENBU_FOLDER}.tar.gz && \
-    tar xzfv ${ZENBU_FOLDER}.tar.gz && \
+    git clone $ZENBU_URL && \
     cd $ZENBU_FOLDER && \
     /sbin/zenbu_build_debian.sh
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-service mysql restart
+chown -R mysql:mysql /var/lib/mysql /var/run/mysqld && service mysql restart
 service apache2 restart
 /sbin/init_db.sh
 zenbu_agent_launcher.sh

--- a/zenbu_build_debian.sh
+++ b/zenbu_build_debian.sh
@@ -21,15 +21,15 @@ chgrp -R www-data /var/lib/zenbu/
 export ZENBU_SRC_DIR=`pwd`
 echo $ZENBU_SRC_DIR
 
-mkdir -p /usr/share/zenbu/src/$ZENBU_FOLDER/sql
+ZENBU_FOLDER="ZENBU_2.11"
+mkdir -p /usr/share/zenbu/src/$ZENBU_FOLDER
+ln -s /usr/share/zenbu/src/$ZENBU_FOLDER /usr/share/zenbu/src/ZENBU
 
 #zenbu source code - when using script packaged with the source code
 #copy the perl lib objects to /usr/share/zenbu/src/ZENBU/lib
-mkdir /usr/share/zenbu/src/ZENBU
-cp -r $ZENBU_SRC_DIR/lib /usr/share/zenbu/src/ZENBU/
+cp -r $ZENBU_SRC_DIR/lib /usr/share/zenbu/src/$ZENBU_FOLDER
 cp -r $ZENBU_SRC_DIR/build_support /usr/share/zenbu/src/$ZENBU_FOLDER/
 cp -r $ZENBU_SRC_DIR/sql /usr/share/zenbu/src/$ZENBU_FOLDER/
-
 cd $ZENBU_SRC_DIR/c++
 make
 
@@ -39,11 +39,11 @@ make
 make install
 
 #make zenbu website
-cp -rp $ZENBU_SRC_DIR/www/zenbu /usr/share/zenbu/www/zenbu_2.11.1
-ln -s /usr/share/zenbu/www/zenbu_2.11.1  /var/www/zenbu
+cp -rp $ZENBU_SRC_DIR/www/zenbu /usr/share/zenbu/www/$ZENBU_FOLDER
+ln -s /usr/share/zenbu/www/$ZENBU_FOLDER  /var/www/zenbu
 cd $ZENBU_SRC_DIR/c++/cgi
 make
-cp -f *cgi /usr/share/zenbu/www/zenbu_2.11.1/cgi/
+cp -f *cgi /usr/share/zenbu/www/$ZENBU_FOLDER/cgi/
 
 #configure zenbu server
 export ZUUID=`uuidgen`


### PR DESCRIPTION
1. Somehow needed to alter the ownership of couple mysql dirs in `entrypoint.sh` in order for the mysqld to (re)start properly. 
2. Made some small modifications such that ZENBU source code gets cloned from the git repo instead of downloaded from sourceforge and ensure all source code versions that are mentioned herein are set to ZENBU_2.11. 
 